### PR TITLE
Update appium-gulp-plugins

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,0 @@
-node_modules
-*.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 sudo: required
 os: osx
 language: node_js
-node_js: "8"
+node_js:
+  - "8"
+  - "10"
 script:
   - npm run test

--- a/index.js
+++ b/index.js
@@ -22,4 +22,3 @@ if (require.main === module) {
 export { MacDriver };
 
 export default MacDriver;
-

--- a/lib/appium-for-mac.js
+++ b/lib/appium-for-mac.js
@@ -80,7 +80,7 @@ class AppiumForMac {
     return this.jwproxy.sessionId;
   }
 
-  async waitForOnline () {
+  async waitForOnline () { // eslint-disable-line require-await
     // TODO: Actually check via HTTP
     return true;
   }

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,11 +1,11 @@
 import log from './logger';
-import { server as baseServer, routeConfiguringFunction  } from 'appium-base-driver';
+import { server as baseServer, routeConfiguringFunction } from 'appium-base-driver';
 import { MacDriver } from './driver';
 
-function startServer (port, address) {
+async function startServer (port, address) {
   let driver = new MacDriver({port, address});
   let router = routeConfiguringFunction(driver);
-  let server = baseServer(router, port, address);
+  let server = await baseServer(router, port, address);
   log.info(`MacDriver server listening on http://${address}:${port}`);
   return server;
 }

--- a/package.json
+++ b/package.json
@@ -24,15 +24,18 @@
   "directories": {
     "lib": "lib"
   },
+  "files": [
+    "index.js",
+    "lib",
+    "build/index.js",
+    "build/lib"
+  ],
   "dependencies": {
+    "@babel/runtime": "^7.0.0",
     "appium-base-driver": "^3.0.0",
     "appium-support": "^2.6.0",
     "asyncbox": "^2.3.1",
-    "babel-runtime": "=5.8.24",
     "bluebird": "^3.5.1",
-    "lodash": "^4.6.1",
-    "punycode": "^2.0.0",
-    "request-promise": "^4.2.2",
     "source-map-support": "^0.5.5",
     "teen_process": "^1.7.0",
     "yargs": "^12.0.1"
@@ -41,7 +44,7 @@
     "clean": "rm -rf node_modules && rm -f package-lock.json && npm install",
     "build": "gulp transpile",
     "mocha": "mocha",
-    "prepublish": "gulp prepublish",
+    "prepare": "gulp prepublish",
     "test": "gulp once",
     "e2e-test": "gulp e2e-test",
     "watch": "gulp watch",
@@ -56,33 +59,23 @@
     "precommit-test"
   ],
   "devDependencies": {
-    "appium-gulp-plugins": "^2.2.0",
+    "ajv": "^6.5.3",
+    "appium-gulp-plugins": "^3.1.0",
     "appium-test-support": "1.0.0",
-    "babel-eslint": "^7.1.1",
+    "babel-eslint": "^10.0.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
-    "eslint": "^3.18.0",
-    "eslint-config-appium": "^2.0.1",
-    "eslint-plugin-babel": "^3.3.0",
+    "eslint": "^5.2.0",
+    "eslint-config-appium": "^3.1.0",
     "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-mocha": "^4.7.0",
-    "eslint-plugin-promise": "^3.3.1",
-    "gulp": "^3.8.11",
+    "eslint-plugin-mocha": "^5.0.0",
+    "eslint-plugin-promise": "^4.0.0",
+    "gulp": "^4.0.0",
     "pre-commit": "^1.2.2",
     "sinon": "^6.0.0",
     "wd": "^1.6.2"
   },
   "greenkeeper": {
-    "ignore": [
-      "babel-eslint",
-      "babel-preset-env",
-      "eslint",
-      "eslint-plugin-babel",
-      "eslint-plugin-import",
-      "eslint-plugin-mocha",
-      "eslint-plugin-promise",
-      "gulp",
-      "babel-runtime"
-    ]
+    "ignore": []
   }
 }

--- a/test/e2e/driver-e2e-specs.js
+++ b/test/e2e/driver-e2e-specs.js
@@ -19,7 +19,7 @@ describe('Driver', function () {
     await server.close();
   });
 
-  beforeEach(async function () {
+  beforeEach(function () {
     driver = wd.promiseChainRemote(TEST_HOST, TEST_PORT);
   });
 


### PR DESCRIPTION
This PR does two main things:
1. Updates `eslint-config-appium` and fixes any linting errors.
1. Updated `appium-gulp-plugins` and moves to Babel 7 and Gulp 4.

See https://github.com/appium/appium-gulp-plugins/pull/35 for more details.