### PR TITLE
feat: Allow to configure host/port/app path for Appium for mac app in appium-mac-driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,32 @@ These can be enabled when running this driver through Appium, via the `--allow-i
 |Feature Name|Description|
 |------------|-----------|
 |`system_shell`|Allows to execute shell scripts on the machine. Read [appium-mac-driver#38](https://github.com/appium/appium-mac-driver/pull/38) for more details on the implementation |
+
+## Desired Capabilities
+
+Should be same for [Appium](https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/caps.md)
+
+Differences are noted here:
+
+### Handling Appium for mac
+
+
+|Capability|Description|Values|
+|----------|-----------|------|
+| `AppiumForMac` | Specify the host name to the app for mac application. Defaults to `127.0.0.1` | e.g., `localhost` |
+| `a4mPort` | Specify the port to the app for mac application. Defaults to `4622` | e.g, `4622`, `8080` |
+| `a4mAppPath` | Specify the path to the app for mac application. It helps to launch `AppiumForMac` application in a custom path. Defaults to `/Applications/AppiumForMac.app` | e.g, `/Applications/CustomAppiumForMac.app` |
+| `killAllA4MAppBeforeStart` | Kill all running processes named `AppiumForMac` not to remain the process in next Appium session run. Please disable this value when you run multiple `AppiumForMac` on the machine. Defaults to `true` | `false`, `true` |
+| `implicitTimeout` |  | |
+| `loopDelay` |  | |
+| `commandDelay` |  | |
+| `mouseMoveSpeed` |  | |
+| `diagnosticsDirectoryLocation` |  | |
+| `screenShotOnError` |  | |
+
+
+### Customize the port of AppiumForMac
+
+You can launch multiple `AppiumForMac` on the host machine to run tests in parallel.
+Please consider to set `a4mPort`, `a4mAppPath` and `killAllA4MAppBeforeStart` to handle multiple Appium sessions on the machine.
+You must modify [the port number in appium-for-mac](https://github.com/appium/appium-for-mac/blob/2356957dc73b6275262c918ca8f4184ef4a25af0/AppiumForMac/AppiumForMacAppDelegate.m#L36) and build the app to coordinate the port number in `AppiumForMac` side.

--- a/README.md
+++ b/README.md
@@ -77,4 +77,4 @@ Differences are noted here:
 
 You can launch multiple `AppiumForMac` on the host machine to run tests in parallel.
 Please consider to set `a4mPort`, `a4mAppPath` and `killAllA4MAppBeforeStart` to handle multiple Appium sessions on the machine.
-You must modify [the port number in appium-for-mac](https://github.com/appium/appium-for-mac/blob/2356957dc73b6275262c918ca8f4184ef4a25af0/AppiumForMac/AppiumForMacAppDelegate.m#L36) and build the app to coordinate the port number in `AppiumForMac` side.
+You must modify [the port number in appium-for-mac](https://github.com/appium/appium-for-mac/blob/2356957dc73b6275262c918ca8f4184ef4a25af0/AppiumForMac/AppiumForMacAppDelegate.m#L36) and build the app to coordinate the port number in `AppiumForMac` side. Do not forget to handle your test scenarios properly not to conflict each other since scenarios running on the same machine can be conflict.

--- a/README.md
+++ b/README.md
@@ -73,8 +73,9 @@ Differences are noted here:
 | `screenShotOnError` |  | |
 
 
-### Customize the port of AppiumForMac
+### Customize the port of AppiumForMac / Run tests in parallel
 
-You can launch multiple `AppiumForMac` on the host machine to run tests in parallel.
-Please consider to set `a4mPort`, `a4mAppPath` and `killAllA4MAppBeforeStart` to handle multiple Appium sessions on the machine.
-You must modify [the port number in appium-for-mac](https://github.com/appium/appium-for-mac/blob/2356957dc73b6275262c918ca8f4184ef4a25af0/AppiumForMac/AppiumForMacAppDelegate.m#L36) and build the app to coordinate the port number in `AppiumForMac` side. Do not forget to handle your test scenarios properly not to conflict each other since scenarios running on the same machine can be conflict.
+You can launch multiple `AppiumForMac` on a same machine to run tests in parallel.
+Please consider to set `a4mPort`, `a4mAppPath` and `killAllA4MAppBeforeStart` as their capabilities to handle multiple Appium sessions on the machine.
+You must modify [the port number in appium-for-mac](https://github.com/appium/appium-for-mac/blob/2356957dc73b6275262c918ca8f4184ef4a25af0/AppiumForMac/AppiumForMacAppDelegate.m#L36) and build the app to coordinate the port number on `AppiumForMac`. Appium-mac-driver tries to establish a session to the host/port referencing `a4mPort` and `a4mAppPath`.
+Do not forget to handle your test scenarios properly not to conflict each other since the scenarios runs on the machine.

--- a/lib/appium-for-mac.js
+++ b/lib/appium-for-mac.js
@@ -31,7 +31,8 @@ class AppiumForMac {
 
     let processIsAlive = false;
     try {
-      await this.killAll();
+      // TODO: Should kill processes based on available port
+      // await this.killAll();
 
       // set up our subprocess object
       const a4mBinary = path.resolve(this.a4mAppPath, 'Contents', 'MacOS', 'AppiumForMac');

--- a/lib/appium-for-mac.js
+++ b/lib/appium-for-mac.js
@@ -15,13 +15,14 @@ class AppiumForMac {
   constructor (opts = {}) {
     this.proxyHost = opts.a4mHost || DEFAULT_A4M_HOST;
     this.proxyPort = opts.a4mPort || DEFAULT_A4M_PORT;
+    this.a4mAppPath = opts.a4mAppPath || REQ_A4M_APP_PATH;
     this.proc = null;
     this.jwproxy = new JWProxy({server: this.proxyHost, port: this.proxyPort});
   }
 
   async start () {
-    if (!await fs.exists(REQ_A4M_APP_PATH)) {
-      throw new Error('Could not verify AppiumForMacDriver install; please install to your /Applications folder');
+    if (!await fs.exists(this.a4mAppPath)) {
+      throw new Error(`Could not verify AppiumForMacDriver install in ${this.a4mAppPath}; please install it to ${this.a4mAppPath}`);
     }
 
     const startDetector = (stdout, stderr) => {
@@ -33,7 +34,7 @@ class AppiumForMac {
       await this.killAll();
 
       // set up our subprocess object
-      const a4mBinary = path.resolve(REQ_A4M_APP_PATH, 'Contents', 'MacOS', 'AppiumForMac');
+      const a4mBinary = path.resolve(this.a4mAppPath, 'Contents', 'MacOS', 'AppiumForMac');
       this.proc = new SubProcess(a4mBinary, []);
       processIsAlive = true;
 
@@ -55,7 +56,7 @@ class AppiumForMac {
                   `signal ${signal}`;
         log.error(msg);
       });
-      log.info(`Spawning AppiumForMac with: ${this.appium4macdriver}`);
+      log.info(`Spawning AppiumForMac with: ${this.a4mAppPath}`);
 
       // start subproc and wait for startDetector
       await this.proc.start(startDetector);

--- a/lib/appium-for-mac.js
+++ b/lib/appium-for-mac.js
@@ -12,9 +12,9 @@ const REQ_A4M_APP_PATH = path.resolve('/Applications', 'AppiumForMac.app');
 const a4mLog = logger.getLogger('Appium4Mac');
 
 class AppiumForMac {
-  constructor () {
-    this.proxyHost = DEFAULT_A4M_HOST;
-    this.proxyPort = DEFAULT_A4M_PORT;
+  constructor (opts = {}) {
+    this.proxyHost = opts.a4mHost || DEFAULT_A4M_HOST;
+    this.proxyPort = opts.a4mPort || DEFAULT_A4M_PORT;
     this.proc = null;
     this.jwproxy = new JWProxy({server: this.proxyHost, port: this.proxyPort});
   }

--- a/lib/appium-for-mac.js
+++ b/lib/appium-for-mac.js
@@ -16,6 +16,7 @@ class AppiumForMac {
     this.proxyHost = opts.a4mHost || DEFAULT_A4M_HOST;
     this.proxyPort = opts.a4mPort || DEFAULT_A4M_PORT;
     this.a4mAppPath = opts.a4mAppPath || REQ_A4M_APP_PATH;
+    this.killAllA4MAppBeforeStart = opts.killAllA4MAppBeforeStart || true;
     this.proc = null;
     this.jwproxy = new JWProxy({server: this.proxyHost, port: this.proxyPort});
   }
@@ -31,8 +32,9 @@ class AppiumForMac {
 
     let processIsAlive = false;
     try {
-      // TODO: Should kill processes based on available port
-      // await this.killAll();
+      if (this.killAllA4MAppBeforeStart) {
+        await this.killAll();
+      }
 
       // set up our subprocess object
       const a4mBinary = path.resolve(this.a4mAppPath, 'Contents', 'MacOS', 'AppiumForMac');

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -31,7 +31,13 @@ const desiredCapConstraints = {
   },
   screenShotOnError: {
     isNumber: true
-  }
+  },
+  a4mHost: {
+    isString: true
+  },
+  a4mPort: {
+    isNumber: true
+  },
 };
 
 export default desiredCapConstraints;

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -1,5 +1,5 @@
 const desiredCapConstraints = {
-  platformName: {
+  platformName: { // override
     presence: true,
     isString: true,
     inclusionCaseInsensitive: ['Mac']
@@ -38,6 +38,9 @@ const desiredCapConstraints = {
   a4mPort: {
     isNumber: true
   },
+  a4mAppPath: {
+    isString: true
+  }
 };
 
 export default desiredCapConstraints;

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -40,6 +40,9 @@ const desiredCapConstraints = {
   },
   a4mAppPath: {
     isString: true
+  },
+  killAllA4MAppBeforeStart: {
+    isBoolean: true
   }
 };
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1,6 +1,7 @@
 import { BaseDriver } from 'appium-base-driver';
 import { system } from 'appium-support';
 import { AppiumForMac, DEFAULT_A4M_HOST} from './appium-for-mac';
+import desiredCapConstraints from './desired-caps';
 import logger from './logger';
 import commands from './commands/index';
 import _ from 'lodash';
@@ -15,6 +16,8 @@ class MacDriver extends BaseDriver {
     super(opts, shouldValidateCaps);
     this.jwpProxyActive = false;
     this.opts.address = opts.address || DEFAULT_A4M_HOST;
+
+    this.desiredCapConstraints = desiredCapConstraints;
 
     for (const [cmd, fn] of _.toPairs(commands)) {
       MacDriver.prototype[cmd] = fn;
@@ -40,7 +43,7 @@ class MacDriver extends BaseDriver {
   }
 
   async startAppiumForMacSession () {
-    this.a4mDriver = new AppiumForMac(this.ops);
+    this.a4mDriver = new AppiumForMac(this.opts);
 
     await this.a4mDriver.start();
     await this.a4mDriver.startSession(this.caps);

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -40,7 +40,7 @@ class MacDriver extends BaseDriver {
   }
 
   async startAppiumForMacSession () {
-    this.a4mDriver = new AppiumForMac();
+    this.a4mDriver = new AppiumForMac(this.ops);
 
     await this.a4mDriver.start();
     await this.a4mDriver.startSession(this.caps);


### PR DESCRIPTION
[updated]
This PR allows users to configure port/host/path to connect to [appium-for-mac](https://github.com/appium/appium-for-mac). Users must build a4m after changing https://github.com/appium/appium-for-mac/blob/2356957dc73b6275262c918ca8f4184ef4a25af0/AppiumForMac/AppiumForMacAppDelegate.m#L36 . So, this usage is a more advanced one.

---

Related to https://github.com/appium/appium-for-mac/issues/79

@sankalpphirke 
What about with this branch?
You can configure the host/port with `a4mHost` and `a4mPort` capabilities.

i.e.
```
[HTTP] --> POST /wd/hub/session
[HTTP] {"desiredCapabilities":{"automationName":"mac","platformName":"mac","a4mHost":"localhost","a4mPort":9090},"capabilities":{"firstMatch":[{"appium:automationName":"mac","platformName":"mac","appium:a4mHost":"localhost","appium:a4mPort":9090}]}}
[debug] [W3C] Calling AppiumDriver.createSession() with args: [{"automationName":"mac","platformName":"mac","a4mHost":"localhost","a4mPort":9090},null,{"firstMatch":[{"appium:automationName":"mac","platformName":"mac","appium:a4mHost":"localhost","appium:a4mPort":9090}]}]
[debug] [BaseDriver] Event 'newSessionRequested' logged at 1578150445992 (00:07:25 GMT+0900 (Japan Standard Time))
[Appium] Appium v1.16.0-beta.3 creating new MacDriver (v1.8.0) session
[debug] [BaseDriver] W3C capabilities and MJSONWP desired capabilities were provided
[debug] [BaseDriver] Creating session with W3C capabilities: {
[debug] [BaseDriver]   "alwaysMatch": {
[debug] [BaseDriver]     "platformName": "mac",
[debug] [BaseDriver]     "appium:automationName": "mac",
[debug] [BaseDriver]     "appium:a4mHost": "localhost",
[debug] [BaseDriver]     "appium:a4mPort": 9090
[debug] [BaseDriver]   },
[debug] [BaseDriver]   "firstMatch": [
[debug] [BaseDriver]     {}
[debug] [BaseDriver]   ]
[debug] [BaseDriver] }
[BaseDriver] Session created with session id: 49941c74-9178-4e07-aa22-bdbf6da7445e
[MacDriver] Killing any old AppiumForMac
[MacDriver] Successfully cleaned up old Appium4Mac servers
[MacDriver] Spawning AppiumForMac with: undefined
[Appium4Mac] [STDERR] 2020-01-05 00:07:26:914 AppiumForMac[59877:307] HTTPServer: Started HTTP server on port 4622
[debug] [WD Proxy] Matched '/session' to command name 'createSession'
[debug] [WD Proxy] Proxying [POST /session] to [POST http://localhost:9090/wd/hub/session] with body: {"desiredCapabilities":{"platformName":"mac","automationName":"mac","a4mHost":"localhost","a4mPort":9090}}
[WD Proxy] Got an unexpected response with status undefined: {"errno":"ECONNREFUSED","code":"ECONNREFUSED","syscall":"connect","address":"127.0.0.1","port":9090}
[debug] [MacDriver] Deleting AppiumForMac session
[debug] [BaseDriver] Event 'newSessionStarted' logged at 1578150446934 (00:07:26 GMT+0900 (Japan Standard Time))
[debug] [W3C] Encountered internal error running command: UnknownError: An unknown server-side error occurred while processing the command. Original error: Could not proxy command to remote server. Original error: Error: connect ECONNREFUSED 127.0.0.1:9090
[debug] [W3C]     at JWProxy.command (/Users/kazu/GitHub/appium-mac-driver/node_modules/appium-base-driver/lib/jsonwp-proxy/proxy.js:270:13)
[HTTP] <-- POST /wd/hub/session 500 957 ms - 574
```

You can:

```
git clone git@github.com:appium/appium.git
cd appium && npm install
git clone git@github.com:KazuCocoa/appium-mac-driver.git
cd appium-mac-driver && git checkout make-port-configuable && npm install && npm link

cd appium && npm link appium-mac-driver
node . # in appium directory
```