### PR TITLE
feat: Support get_server_logs

### DIFF
--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -1,9 +1,11 @@
 import executeCmds from './execute';
+import loggingCommands from './logging';
 
 const commands = {};
 Object.assign(
   commands,
   executeCmds,
+  loggingCommands
   // add other command types here
 );
 

--- a/lib/commands/logging.js
+++ b/lib/commands/logging.js
@@ -1,0 +1,28 @@
+import logger from '../logger';
+import _ from 'lodash';
+
+const GET_SERVER_LOGS_FEATURE = 'get_server_logs';
+
+const extensions = {};
+
+extensions.supportedLogTypes = {
+  server: {
+    description: 'Appium server logs',
+    getter: (self) => {
+      self.ensureFeatureEnabled(GET_SERVER_LOGS_FEATURE);
+      return logger.unwrap().record
+        .map(function (x) {
+          return {
+            // npmlog does not keep timestamps in the history
+            timestamp: Date.now(),
+            level: 'ALL',
+            message: _.isEmpty(x.prefix) ? x.message : `[${x.prefix}] ${x.message}`,
+          };
+        });
+    },
+  },
+};
+
+Object.assign(extensions);
+
+export default extensions;

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -12,7 +12,9 @@ import { findAppPath } from './utils';
 
 
 const NO_PROXY_LIST = [
+  ['GET', new RegExp('^/session/[^/]+/log/types')],
   ['POST', new RegExp('^/session/[^/]+/execute')],
+  ['POST', new RegExp('^/session/[^/]+/log')],
 ];
 
 // Appium instantiates this class


### PR DESCRIPTION
Behind regular `get_server_logs` in http://appium.io/docs/en/writing-running-appium/security/index.html

This is a part of https://github.com/appium/appium-for-mac/issues/90 .
appium for mac does not have this endpoint so far, so only returns Appium server's log.
https://github.com/appium/appium-for-mac/blob/6763cbffb0fd07369b58868fe6e9e92b23ebb100/AppiumForMac/Server/Handlers/AfMHandlers.m#L1040-L1044

If this log is expected one by https://github.com/appium/appium-for-mac/issues/90 , would like to add this.