### PR TITLE
fix: update to current implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,7 @@ Differences are noted here:
 | `a4mPort` | Specify the port to the app for mac application. Defaults to `4622` | e.g, `4622`, `8080` |
 | `a4mAppPath` | Specify the path to the app for mac application. It helps to launch `AppiumForMac` application in a custom path. Defaults to `/Applications/AppiumForMac.app` | e.g, `/Applications/CustomAppiumForMac.app` |
 | `killAllA4MAppBeforeStart` | Kill all running processes named `AppiumForMac` not to remain the process in next Appium session run. Please disable this value when you run multiple `AppiumForMac` on the same machine. Defaults to `true` | `false`, `true` |
-| `implicitTimeout` |  | |
-| `loopDelay` |  | |
-| `commandDelay` |  | |
-| `mouseMoveSpeed` |  | |
-| `diagnosticsDirectoryLocation` |  | |
-| `screenShotOnError` |  | |
-
+| `cookies` | Set propertires for [appium-for-mac](https://github.com/appium/appium-for-mac). Please read [this section](https://github.com/appium/appium-for-mac#new-session-properties) for more details. | `[{'name': 'implicit_timeout', 'value': 20.5}]` |
 
 ### Customize the port of AppiumForMac / Run tests in parallel
 

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -10,27 +10,12 @@ const desiredCapConstraints = {
   deviceName: {
     presence: false
   },
+  cookies: {
+    isArray: true
+  },
   processArguments: {
     // recognize the cap,
     // but validate in the driver#validateDesiredCaps method
-  },
-  implicitTimeout: {
-    isNumber: true
-  },
-  loopDelay: {
-    isNumber: true
-  },
-  commandDelay: {
-    isNumber: true
-  },
-  mouseMoveSpeed: {
-    isNumber: true
-  },
-  diagnosticsDirectoryLocation: {
-    isString: true
-  },
-  screenShotOnError: {
-    isNumber: true
   },
   a4mHost: {
     isString: true

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -17,6 +17,24 @@ const desiredCapConstraints = {
     // recognize the cap,
     // but validate in the driver#validateDesiredCaps method
   },
+  implicitTimeout: {
+    isNumber: true
+  },
+  loopDelay: {
+    isNumber: true
+  },
+  commandDelay: {
+    isNumber: true
+  },
+  mouseMoveSpeed: {
+    isNumber: true
+  },
+  diagnosticsDirectoryLocation: {
+    isString: true
+  },
+  screenShotOnError: {
+    isNumber: true
+  },
   a4mHost: {
     isString: true
   },


### PR DESCRIPTION
By this change, this repository can detect `cookies`.
Other parameters do not work for the current implementation. They must be part of `cookies` like https://github.com/appium/appium-for-mac/blob/master/examples/dock_demo.py#L18-L25

```
[Appium] Welcome to Appium v1.18.0-beta.0 (REV 39e2fe1c2b392ebdf386fe4888d12cf1e45b49ee)
[Appium] Appium REST http interface listener started on 0.0.0.0:4723
[debug] [HTTP] Request idempotency key: 25a1a5df-ca97-4a0c-b44b-1c338ffb7be4
[HTTP] --> POST /wd/hub/session
[HTTP] {"desiredCapabilities":{"platformName":"mac","cookies":[{"name":"loop_delay","value":1},{"name":"command_delay","value":0.1},{"name":"implicit_timeout","value":3},{"name":"mouse_speed","value":50},{"name":"screen_shot_on_error","value":true},{"name":"global_diagnostics_directory","value":"~/Desktop/sample/neko"}]},"capabilities":{"firstMatch":[{"platformName":"mac","appium:cookies":[{"name":"loop_delay","value":1},{"name":"command_delay","value":0.1},{"name":"implicit_timeout","value":3},{"name":"mouse_speed","value":50},{"name":"screen_shot_on_error","value":true},{"name":"global_diagnostics_directory","value":"~/Desktop/sample/neko"}]}]}}
[debug] [W3C] Calling AppiumDriver.createSession() with args: [{"platformName":"mac","cookies":[{"name":"loop_delay","value":1},{"name":"command_delay","value":0.1},{"name":"implicit_timeout","value":3},{"name":"mouse_speed","value":50},{"name":"screen_shot_on_error","value":true},{"name":"global_diagnostics_directory","value":"~/Desktop/sample/neko"}]},null,{"firstMatch":[{"platformName":"mac","appium:cookies":[{"name":"loop_delay","value":1},{"name":"command_delay","value":0.1},{"name":"implicit_timeout","value":3},{"name":"mouse_speed","value":50},{"name":"screen_shot_on_error","value":true},{"name":"global_diagnostics_directory","value":"~/Desktop/sample/neko"}]}]}]
[debug] [BaseDriver] Event 'newSessionRequested' logged at 1594310744971 (01:05:44 GMT+0900 (Japan Standard Time))
[Appium] Appium v1.18.0-beta.0 creating new MacDriver (v1.10.0) session
[debug] [BaseDriver] W3C capabilities and MJSONWP desired capabilities were provided
[debug] [BaseDriver] Creating session with W3C capabilities: {
[debug] [BaseDriver]   "alwaysMatch": {
[debug] [BaseDriver]     "platformName": "mac",
[debug] [BaseDriver]     "appium:cookies": [
[debug] [BaseDriver]       {
[debug] [BaseDriver]         "name": "loop_delay",
[debug] [BaseDriver]         "value": 1
[debug] [BaseDriver]       },
[debug] [BaseDriver]       {
[debug] [BaseDriver]         "name": "command_delay",
[debug] [BaseDriver]         "value": 0.1
[debug] [BaseDriver]       },
[debug] [BaseDriver]       {
[debug] [BaseDriver]         "name": "implicit_timeout",
[debug] [BaseDriver]         "value": 3
[debug] [BaseDriver]       },
[debug] [BaseDriver]       {
[debug] [BaseDriver]         "name": "mouse_speed",
[debug] [BaseDriver]         "value": 50
[debug] [BaseDriver]       },
[debug] [BaseDriver]       {
[debug] [BaseDriver]         "name": "screen_shot_on_error",
[debug] [BaseDriver]         "value": true
[debug] [BaseDriver]       },
[debug] [BaseDriver]       {
[debug] [BaseDriver]         "name": "global_diagnostics_directory",
[debug] [BaseDriver]         "value": "~/Desktop/sample/neko"
[debug] [BaseDriver]       }
[debug] [BaseDriver]     ]
[debug] [BaseDriver]   },
[debug] [BaseDriver]   "firstMatch": [
[debug] [BaseDriver]     {}
[debug] [BaseDriver]   ]
[debug] [BaseDriver] }
[BaseDriver] Session created with session id: db4a454e-df32-4e6b-abd2-4bbf733f03ff
[debug] [MacDriver] The path to AppiumForMac server has not been provided explicitly. Trying to autodetect it
[debug] [MacDriver] Got multiple apps having the bundle identifier 'com.appium.AppiumForMac': /Users/kazuaki/Library/Developer/Xcode/DerivedData/AppiumForMac-apzdafqjrsydnwbfltwoopkbabpe/Build/Products/Debug/AppiumForMac.app,/Applications/AppiumForMac.app. Will return the most recent one
[MacDriver] Autodetected AppiumForMac server's location at '/Users/kazuaki/Library/Developer/Xcode/DerivedData/AppiumForMac-apzdafqjrsydnwbfltwoopkbabpe/Build/Products/Debug/AppiumForMac.app'
[MacDriver] Killing any old AppiumForMac
[MacDriver] Successfully cleaned up old Appium4Mac servers
[MacDriver] Spawning AppiumForMac with: /Users/kazuaki/Library/Developer/Xcode/DerivedData/AppiumForMac-apzdafqjrsydnwbfltwoopkbabpe/Build/Products/Debug/AppiumForMac.app
[Appium4Mac] [STDERR] 2020-07-10 01:05:47:461 AppiumForMac[24576:307] HTTPServer: Failed to start HTTP Server: Error Domain=NSPOSIXErrorDomain Code=48 "Address already in use" UserInfo={NSLocalizedDescription=Address already in use, NSLocalizedFailureReason=Error in bind() function}
```